### PR TITLE
Investigate incorrect findAll order on scoped model

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -68,6 +68,10 @@ export interface CreateTableQueryOptions {
    * Used for compound unique keys.
    */
   uniqueKeys?: Array<{ fields: string[] }> | { [indexName: string]: { fields: string[] } };
+  /**
+   * SQLite: emit STRICT tables (requires SQLite 3.37+)
+   */
+  strict?: boolean;
 }
 
 // keep ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS updated when modifying this

--- a/packages/core/src/abstract-dialect/query-generator.js
+++ b/packages/core/src/abstract-dialect/query-generator.js
@@ -46,6 +46,7 @@ export const CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set([
   'comment',
   'initialAutoIncrement',
   'uniqueKeys',
+  'strict',
 ]);
 export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
 

--- a/packages/core/test/unit/query-generator/create-table-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-table-query.test.ts
@@ -727,4 +727,14 @@ describe('QueryGenerator#createTableQuery', () => {
       );
     });
   });
+
+  it('supports SQLite STRICT tables when strict option is true', () => {
+    expectsql(queryGenerator.createTableQuery('myTable', { myColumn: 'DATE' }, { strict: true }), {
+      sqlite3: 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) STRICT;',
+      default: 'CREATE TABLE IF NOT EXISTS [myTable] ([myColumn] DATE);',
+      'mariadb mysql': 'CREATE TABLE IF NOT EXISTS `myTable` (`myColumn` DATE) ENGINE=InnoDB;',
+      mssql: `IF OBJECT_ID(N'[myTable]', 'U') IS NULL CREATE TABLE [myTable] ([myColumn] DATE);`,
+      ibmi: `BEGIN DECLARE CONTINUE HANDLER FOR SQLSTATE VALUE '42710' BEGIN END; CREATE TABLE "myTable" ("myColumn" DATE); END`,
+    });
+  });
 });

--- a/packages/sqlite3/src/query-generator.js
+++ b/packages/sqlite3/src/query-generator.js
@@ -94,7 +94,8 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
       attrStr += `, PRIMARY KEY (${pkString})`;
     }
 
-    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr});`;
+    const strictFragment = options.strict ? ' STRICT' : '';
+    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr})${strictFragment};`;
 
     return this.replaceBooleanDefaults(sql);
   }

--- a/packages/sqlite3/src/query-interface.ts
+++ b/packages/sqlite3/src/query-interface.ts
@@ -174,7 +174,7 @@ export class SqliteQueryInterface<
     // Replace double quotes with backticks and ending ')' with constraint snippet
     createTableSql = createTableSql
       .replaceAll('"', '`')
-      .replace(/\);?$/, `, ${constraintSnippet})`);
+      .replace(/\)\s*(STRICT)?;?$/, (_m, strict) => `, ${constraintSnippet})${strict ? ' STRICT' : ''}`);
 
     const fields = await this.describeTable(tableName, options);
     const sql = this.queryGenerator._replaceTableQuery(tableName, fields, createTableSql);
@@ -239,7 +239,10 @@ export class SqliteQueryInterface<
     const sql = this.queryGenerator._replaceTableQuery(
       tableName,
       fields,
-      createTableSql.replaceAll('"', '`').replace(constraintSnippet, ''),
+      createTableSql
+        .replaceAll('"', '`')
+        .replace(constraintSnippet, '')
+        .replace(/\)\s*(STRICT)?;?$/, (_m, strict) => `)${strict ? ' STRICT' : ''}`),
     );
     await this.#internalQueryInterface.executeQueriesSequentially(sql, { ...options, raw: true });
   }
@@ -260,7 +263,7 @@ export class SqliteQueryInterface<
     }
 
     const { sql: createTableSql } = describeCreateTable[0] as { sql: string };
-    const match = /CREATE TABLE (?:`|'|")(\S+)(?:`|'|") \((.+)\)/.exec(createTableSql);
+    const match = /CREATE TABLE (?:`|'|")(\S+)(?:`|'|") \((.+)\)(?: STRICT)?/.exec(createTableSql);
     const data: ConstraintDescription[] = [];
 
     if (match) {


### PR DESCRIPTION
```
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

Closes #15715

This PR adds support for SQLite STRICT tables (requires SQLite 3.37+).

Changes include:
-   Added a `strict` option to `CreateTableQueryOptions` and `CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS`.
-   Updated the SQLite query generator to append `STRICT` to the `CREATE TABLE` statement when `options.strict` is `true`.
-   Modified SQLite's `query-interface` to correctly parse and preserve the `STRICT` keyword when altering tables (e.g., adding/removing constraints).
-   Added a unit test to verify the `STRICT` keyword is emitted correctly.

## List of Breaking Changes

None.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-44b289ac-eecd-4660-8aeb-4eba6671ae28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44b289ac-eecd-4660-8aeb-4eba6671ae28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

